### PR TITLE
Fixes examples and mocks documentation errors

### DIFF
--- a/docs/MOCKS.md
+++ b/docs/MOCKS.md
@@ -3,7 +3,7 @@
 This projects makes use of [vektra/mockery][] to mock [config][] interfaces for unit testing. If any interface changes occurs, you'll need to update the mocks with the following command ([mockery cli][vektra/mockery#installation] will need to be installed):
 
 ```bash
-mockery -all -case underscore -dir ./pkg -output ./test/mocks
+mockery -all -case underscore -dir ./pkg -output ./internal/mocks
 ```
 
 [vektra/mockery]: https://github.com/vektra/mockery

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,7 @@
 
 This section provides examples of how to build and use a configuration providers.
 
-- [yaml](yaml/README.md): Composing a configuration provider from [spf13/viper] library.
-- [viper](viper/README.md): Load and merge multiple YAML configuration files into a configuration provider.
+- [yaml](yaml/README.md): Load and merge multiple YAML configuration files into a configuration provider.
+- [viper](viper/README.md): Composing a configuration provider from [spf13/viper][] library.
+
+[spf13/viper]: https://github.com/spf13/viper

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -6,13 +6,13 @@ informed, they will be merged, and the last file will have higher precedence fro
 ## Usage
 
 ```bash
-go run examples/yaml/main.go -f ${COMMA_DELIMITED_YAML_FILES}
+go run main.go -f ${COMMA_DELIMITED_YAML_FILES}
 ```
 
 ## Example
 
 ```bash
-$ go run examples/yaml/main.go -f test/samples/assets/config.yml
+$ go run main.go -f ../../assets/test_data
 
 yac.data:test/samples/assets/config.yml loaded (1/1)
 Config [data:test/samples/assets/config.yml]:


### PR DESCRIPTION
- Example index documentation page had yaml
and viper descriptions were swapped.
- Link to viper project was broken.
- YAML cli example was pointing to the wrong
asset directory.
- Command example was poiting to wrong output
dir.