### PR TITLE
Fixes golint violations and adds validation in CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ before_install:
   - chmod +x $GOPATH/bin/dep
 
 install:
+  - go get golang.org/x/lint/golint
   - go get github.com/mattn/goveralls
   - dep ensure -v
 
 script:
+  - golint -set_exit_status ./pkg/... ./internal/... ./examples/yaml ./examples/viper
   - go test -v ./... -coverpkg=./... -coverprofile=coverage.out
   - goveralls -coverprofile=coverage.out -service=travis-ci -ignore="examples/*/*.go,internal/mocks/*.go,internal/samples/*.go"

--- a/examples/viper/loader.go
+++ b/examples/viper/loader.go
@@ -5,11 +5,15 @@ import (
 	"github.com/spf13/viper"
 )
 
+// ViperLoader is a loader implementation for config.Loader interface
 type ViperLoader struct {
+	// Name for viper loading configuration
 	Name string
+	//  Path directory to load configuration files from
 	Path string
 }
 
+// Load creates a config.Provider implementation from viper source
 func (l *ViperLoader) Load() (config.Provider, error) {
 	viper.SetConfigName(l.Name)
 	viper.AddConfigPath(l.Path)

--- a/examples/viper/provider.go
+++ b/examples/viper/provider.go
@@ -2,49 +2,60 @@ package main
 
 import "github.com/spf13/viper"
 
+// ViperProvider is an implementation for config.Provider
 type ViperProvider struct {
-	ConfigName string
-	Viper      *viper.Viper
+	// Viper instance associated with this provider
+	Viper *viper.Viper
 }
 
+// Source returns associated viper configuration source
 func (v *ViperProvider) Source() string {
 	return v.Viper.ConfigFileUsed()
 }
 
+// Set delegates data to viper.Set
 func (v *ViperProvider) Set(name string, value interface{}) interface{} {
 	previous, _ := v.Get(name)
 	viper.Set(name, value)
 	return previous
 }
 
+// Get configuration data from viper
 func (v *ViperProvider) Get(name string) (interface{}, bool) {
 	return v.Viper.Get(name), v.IsSet(name)
 }
 
+// IsSet checks if configuration exists in viper
 func (v *ViperProvider) IsSet(name string) bool {
 	return v.Viper.IsSet(name)
 }
 
+// AllSettings delegates to viper.AllSettings
 func (v *ViperProvider) AllSettings() map[string]interface{} {
 	return v.Viper.AllSettings()
 }
 
+// String delegates to viper.GetString
 func (v *ViperProvider) String(name string) string {
 	return v.Viper.GetString(name)
 }
 
+// Int delegates to viper.GetInt
 func (v *ViperProvider) Int(name string) int {
 	return v.Viper.GetInt(name)
 }
 
+// Float delegates to viper.GetFloat64
 func (v *ViperProvider) Float(name string) float64 {
 	return v.Viper.GetFloat64(name)
 }
 
+// Bool delegates to viper.GetBool
 func (v *ViperProvider) Bool(name string) bool {
 	return v.Viper.GetBool(name)
 }
 
+// StringSlice delegates to viper.GetStringSlice
 func (v *ViperProvider) StringSlice(name string) []string {
 	return v.Viper.GetStringSlice(name)
 }

--- a/internal/samples/samples.go
+++ b/internal/samples/samples.go
@@ -1,4 +1,4 @@
-// samples package helps this project's tests, providing filesystem assets
+// Package samples helps this project's tests, providing filesystem assets
 package samples
 
 import (

--- a/pkg/composite/provider.go
+++ b/pkg/composite/provider.go
@@ -88,7 +88,7 @@ func (c *Provider) Set(name string, value interface{}) interface{} {
 	return previous
 }
 
-// Repository returns a merged identifier from the sources associated with this provider
+// Source returns a merged identifier from the sources associated with this provider
 func (c *Provider) Source() string {
 	var sourceNames []string
 	for _, source := range c.Sources {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,11 +2,13 @@
 package config
 
 const (
+	// EmptyString constant to be used along implementations
 	EmptyString = ""
-	Zero        = 0
+	// Zero number constant to be used along implementations
+	Zero = 0
 )
 
-// Repository interface for implementors to provide an identifier regarding loaded configuration
+// Source interface for implementors to provide an identifier regarding loaded configuration
 type Source interface {
 	// Repository function, provides an identifier regarding loaded configuration
 	Source() string

--- a/pkg/loader/data.go
+++ b/pkg/loader/data.go
@@ -1,4 +1,4 @@
-// loader provides reading configuration from streamable data
+// Package loader provides reading configuration from streamable data
 package loader
 
 import (
@@ -32,12 +32,12 @@ type Parser interface {
 	Parse(io.Reader) (map[string]interface{}, error)
 }
 
-// Closer currently just wraps io.Reader, allowing for mock generation when testing with io.Reader
+// IOReader currently just wraps io.Reader, allowing for mock generation when testing with io.Reader
 type IOReader interface {
 	io.Reader
 }
 
-// Closer currently just wraps io.ReadCloser, allowing for mock generation when testing with io.ReadCloser
+// IOReadCloser currently just wraps io.ReadCloser, allowing for mock generation when testing with io.ReadCloser
 type IOReadCloser interface {
 	io.ReadCloser
 }
@@ -66,7 +66,7 @@ func (s *Data) Load() (cfg config.Provider, err error) {
 	return
 }
 
-// Default identifies that this is a data loader and which location is associated to
+// Source identifies that this is a data loader and which location is associated to
 func (s *Data) Source() string {
 	return fmt.Sprintf("data:%v", path.Clean(s.Location))
 }

--- a/pkg/loader/env.go
+++ b/pkg/loader/env.go
@@ -1,4 +1,4 @@
-// loader provides reading configuration from os environment
+// Package loader provides reading configuration from os environment
 package loader
 
 import (
@@ -47,7 +47,7 @@ func (p *EqualDelimiterParser) Load() (cfg config.Provider, err error) {
 	return
 }
 
-// Default identifier for this loader
+// Source returns an identifier for this loader
 func (p *EqualDelimiterParser) Source() string {
 	return fmt.Sprintf("%v:%v*", p.Name, p.Prefix)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,4 +1,4 @@
-// logger package provides an interfaces used to log configuration provisioning default implementations.
+// Package logger provides an interfaces used to log configuration provisioning default implementations.
 // This interface is compatible with stdlib log.Logger (which doesn't have an interface).
 // You may provide your own logger.Logger implementation by swapping logger.Factory provider
 package logger

--- a/pkg/parser/yaml/yaml.go
+++ b/pkg/parser/yaml/yaml.go
@@ -1,4 +1,4 @@
-// yaml package parses yaml data to be used by map configuration databases
+// Package yaml parses yaml data to be used by map configuration databases
 package yaml
 
 import (

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,4 +1,4 @@
-// provider package contains default implementations from config.Provider interface
+// Package provider contains default implementations from config.Provider interface
 package provider
 
 import (
@@ -14,7 +14,7 @@ type Default struct {
 	Repository config.Repository
 }
 
-// Default returns the source name associated with this provider
+// Source returns the source name associated with this provider
 func (c *Default) Source() string {
 	return c.SourceName
 }

--- a/pkg/repository/map.go
+++ b/pkg/repository/map.go
@@ -1,4 +1,4 @@
-// repository package with a map[string]interface{} backed config.Repository implementation
+// Package repository with a map[string]interface{} backed config.Repository implementation
 package repository
 
 // Map implements config.Provider with a map[string]interface{} database


### PR DESCRIPTION
This PR [adds configuration to travis](.travis.yml) to run `golint` in source code, with default settings. If any violation exists the CI job must fail. Also fixes the following issues:

- pkg/composite/provider.go:91:1: comment on exported method Provider.Source should be of the form "Source ..."
- pkg/config/config.go:5:2: exported const EmptyString should have comment (or a comment on this block) or be unexported
- pkg/config/config.go:9:1: comment on exported type Source should be of the form "Source ..." (with optional leading article)
- pkg/loader/data.go:1:1: package comment should be of the form "Package loader ..."
- pkg/loader/data.go:35:1: comment on exported type IOReader should be of the form "IOReader ..." (with optional leading article)
- pkg/loader/data.go:40:1: comment on exported type IOReadCloser should be of the form "IOReadCloser ..." (with optional leading article)
- pkg/loader/data.go:69:1: comment on exported method Data.Source should be of the form "Source ..."
- pkg/loader/env.go:1:1: package comment should be of the form "Package loader ..."
- pkg/loader/env.go:50:1: comment on exported method EqualDelimiterParser.Source should be of the form "Source ..."
- pkg/logger/logger.go:1:1: package comment should be of the form "Package logger ..."
- pkg/parser/yaml/yaml.go:1:1: package comment should be of the form "Package yaml ..."
- pkg/provider/provider.go:1:1: package comment should be of the form "Package provider ..."
- pkg/provider/provider.go:17:1: comment on exported method Default.Source should be of the form "Source ..."
- pkg/repository/map.go:1:1: package comment should be of the form "Package repository ..."
- internal/samples/samples.go:1:1: package comment should be of the form "Package samples ..."
- examples/viper/loader.go:8:6: exported type ViperLoader should have comment or be unexported
- examples/viper/loader.go:13:1: exported method ViperLoader.Load should have comment or be unexported
- examples/viper/provider.go:5:6: exported type ViperProvider should have comment or be unexported
- examples/viper/provider.go:10:1: exported method ViperProvider.Source should have comment or be unexported
- examples/viper/provider.go:14:1: exported method ViperProvider.Set should have comment or be unexported
- examples/viper/provider.go:20:1: exported method ViperProvider.Get should have comment or be unexported
- examples/viper/provider.go:24:1: exported method ViperProvider.IsSet should have comment or be unexported
- examples/viper/provider.go:28:1: exported method ViperProvider.AllSettings should have comment or be unexported
- examples/viper/provider.go:36:1: exported method ViperProvider.Int should have comment or be unexported
- examples/viper/provider.go:40:1: exported method ViperProvider.Float should have comment or be unexported
- examples/viper/provider.go:44:1: exported method ViperProvider.Bool should have comment or be unexported
- examples/viper/provider.go:48:1: exported method ViperProvider.StringSlice should have comment or be unexported