### PR TITLE
Fixes to parse string values to each primitive type

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -3,7 +3,14 @@ package provider
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/andrealbinop/go-yac/pkg/config"
+)
+
+const (
+	base10    = 10
+	bitSize64 = 64
 )
 
 // Default implements config.Provider backed by a config.Repository
@@ -35,9 +42,22 @@ func (c *Default) Int(name string) int {
 	var result int
 	value, ok := c.Get(name)
 	if ok {
-		result, _ = value.(int)
+		result = c.toInt(value)
 	}
 	return result
+}
+
+func (c *Default) toInt(value interface{}) int {
+	result, ok := value.(int)
+	if ok {
+		return result
+	}
+	var resultInt64 int64
+	rawValue, ok := value.(string)
+	if ok {
+		resultInt64, _ = strconv.ParseInt(rawValue, base10, bitSize64)
+	}
+	return int(resultInt64)
 }
 
 // Float returns a float value associated with the key.
@@ -45,7 +65,19 @@ func (c *Default) Float(name string) float64 {
 	var result float64
 	value, ok := c.Get(name)
 	if ok {
-		result, _ = value.(float64)
+		result = c.toFloat64(value)
+	}
+	return result
+}
+
+func (c *Default) toFloat64(value interface{}) float64 {
+	result, ok := value.(float64)
+	if ok {
+		return result
+	}
+	rawValue, ok := value.(string)
+	if ok {
+		result, _ = strconv.ParseFloat(rawValue, bitSize64)
 	}
 	return result
 }
@@ -55,7 +87,19 @@ func (c *Default) Bool(name string) bool {
 	var result bool
 	value, ok := c.Get(name)
 	if ok {
-		result, _ = value.(bool)
+		result = c.toBool(value)
+	}
+	return result
+}
+
+func (c *Default) toBool(value interface{}) bool {
+	result, ok := value.(bool)
+	if ok {
+		return result
+	}
+	rawValue, ok := value.(string)
+	if ok {
+		result, _ = strconv.ParseBool(rawValue)
 	}
 	return result
 }
@@ -65,7 +109,22 @@ func (c *Default) StringSlice(name string) []string {
 	var result []string
 	value, ok := c.Get(name)
 	if ok {
-		result, _ = value.([]string)
+		result = c.toStringSlice(value)
+	}
+	return result
+}
+
+func (c *Default) toStringSlice(value interface{}) []string {
+	var result []string
+	result, ok := value.([]string)
+	if ok {
+		return result
+	}
+	rawValue, ok := value.([]interface{})
+	if ok {
+		for _, str := range rawValue {
+			result = append(result, fmt.Sprint(str))
+		}
 	}
 	return result
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -112,8 +112,20 @@ func TestPropertyInt(t *testing.T) {
 	repository.AssertExpectations(t)
 }
 
+func TestPropertyIntWithRawValue(t *testing.T) {
+	provider, repository := providerWithProperty(existent, "1")
+	assert.Equal(t, valInt, provider.Int(existent))
+	repository.AssertExpectations(t)
+}
+
 func TestPropertyFloat(t *testing.T) {
 	provider, repository := providerWithProperty(existent, valFloat)
+	assert.Equal(t, valFloat, provider.Float(existent))
+	repository.AssertExpectations(t)
+}
+
+func TestPropertyFloatWithRawValue(t *testing.T) {
+	provider, repository := providerWithProperty(existent, "1.0")
 	assert.Equal(t, valFloat, provider.Float(existent))
 	repository.AssertExpectations(t)
 }
@@ -124,10 +136,24 @@ func TestPropertyBool(t *testing.T) {
 	repository.AssertExpectations(t)
 }
 
+func TestPropertyBoolWithRawValue(t *testing.T) {
+	provider, repository := providerWithProperty(existent, "true")
+	assert.Equal(t, valBool, provider.Bool(existent))
+	repository.AssertExpectations(t)
+}
+
 func TestPropertyStringSlice(t *testing.T) {
 	value := []string{valString}
 	provider, repository := providerWithProperty(existent, value)
 	assert.Equal(t, value, provider.StringSlice(existent))
+	repository.AssertExpectations(t)
+}
+
+func TestPropertyStringSliceWithRawValue(t *testing.T) {
+	value := []interface{}{valString, valString}
+	expected := []string{valString, valString}
+	provider, repository := providerWithProperty(existent, value)
+	assert.Equal(t, expected, provider.StringSlice(existent))
 	repository.AssertExpectations(t)
 }
 


### PR DESCRIPTION
The DefaultProvider is not be able to convert string values into float, int, string Slice and bool, but the environments values are always string.
    
This pr provides a string parser for the DefaultProvider to each specified type.
