### PR TITLE
Fixes parsing values with equal sign in env loader

### DIFF
--- a/pkg/loader/env.go
+++ b/pkg/loader/env.go
@@ -37,7 +37,7 @@ func (p *EqualDelimiterParser) Load() (cfg config.Provider, err error) {
 		if !strings.HasPrefix(e, p.Prefix) {
 			continue
 		}
-		pair := strings.Split(e, "=")
+		pair := strings.SplitN(e, "=", 2)
 		key := strings.TrimPrefix(pair[0], p.Prefix)
 		envData[key] = pair[1]
 	}

--- a/pkg/loader/env_test.go
+++ b/pkg/loader/env_test.go
@@ -13,6 +13,8 @@ const (
 	propB      = "prop.b.key"
 	propAvalue = "prop.a.value"
 	propBvalue = "prop.b.value"
+	propContainingEqualSign = "prop.withequalsign"
+	propContainingEqualSignValue = "prop.withequalsign.key=value"
 )
 
 func TestEnvSource(t *testing.T) {
@@ -33,5 +35,18 @@ func assertSource(t *testing.T, loader func(string) config.Loader) {
 		assert.Equal(t, propAvalue, cfg.String(propA))
 		assert.False(t, cfg.IsSet(propB))
 		assert.Len(t, cfg.AllSettings(), 1)
+	}
+}
+
+func TestEqualDelimiterParser_ValueWithEqualSign(t *testing.T) {
+	parser := EqualDelimiterParser{
+		Name: "",
+		Prefix: "",
+		Data: []string{propContainingEqualSign + "=" + propContainingEqualSignValue},
+
+	}
+	cfg, err := parser.Load()
+	if assert.NotNil(t, cfg) && assert.NoError(t, err) {
+		assert.Equal(t, propContainingEqualSignValue, cfg.String(propContainingEqualSign))
 	}
 }


### PR DESCRIPTION
This commit fixes `loader.EqualDelimiterParser.Load()` function to properly handle values containing `=`. For example, if `prop=a=b` then `loader.EqualDelimiterParser.Load()` would parse `prop=a`. With this commit the value will be `a=b` as expected.