### PR TITLE
Adds property parser to get values into an integer slice

### DIFF
--- a/assets/test_data/config.yml
+++ b/assets/test_data/config.yml
@@ -6,6 +6,9 @@ data:
   stringSlice:
     - "string1"
     - "string2"
+  intSlice:
+    - 400
+    - 423
   nested:
     string: "nested.string"
     int: 2
@@ -14,3 +17,6 @@ data:
     stringSlice:
     - "nested.string1"
     - "nested.string2"
+    intSlice:
+      - 500
+      - 523

--- a/internal/mocks/valueconverter.go
+++ b/internal/mocks/valueconverter.go
@@ -80,3 +80,19 @@ func (_m *ValueConverter) ToStringSlice(_a0 interface{}) []string {
 
 	return r0
 }
+
+// ToIntSlice provides a mock function with given fields: _a0
+func (_m *ValueConverter) ToIntSlice(_a0 interface{}) []int {
+	ret := _m.Called(_a0)
+
+	var r0 []int
+	if rf, ok := ret.Get(0).(func(interface{}) []int); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+
+	return r0
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,8 @@ type Provider interface {
 	Bool(string) bool
 	// StringSlice returns a string slice value associated with the key.
 	StringSlice(string) []string
+	// IntSlice returns a int slice value associated with the key.
+	IntSlice(string) []int
 }
 
 // ValueConverter interface for parser values into specific types
@@ -54,6 +56,8 @@ type ValueConverter interface {
 	ToBool(interface{}) bool
 	// ToStringSlice parses a value into string slice
 	ToStringSlice(interface{}) []string
+	// ToIntSlice parses a value into int slice
+	ToIntSlice(interface{}) []int
 }
 
 // ValueResolver interface to customize property recovery by name

--- a/pkg/parser/yaml/yaml_test.go
+++ b/pkg/parser/yaml/yaml_test.go
@@ -36,11 +36,13 @@ func TestParseWithNestedProperties(t *testing.T) {
 			"data.float":              1.0,
 			"data.bool":               true,
 			"data.stringSlice":        []interface{}{"string1", "string2"},
+			"data.intSlice":           []interface{}{400, 423},
 			"data.nested.string":      "nested.string",
 			"data.nested.int":         2,
 			"data.nested.float":       2.0,
 			"data.nested.bool":        true,
 			"data.nested.stringSlice": []interface{}{"nested.string1", "nested.string2"},
+			"data.nested.intSlice":    []interface{}{500, 523},
 		}, data)
 	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -73,6 +73,17 @@ func (c *Default) StringSlice(name string) []string {
 	return result
 }
 
+
+// IntSlice returns a int slice value associated with the key.
+func (c *Default) IntSlice(name string) []int {
+	var result []int
+	value, ok := c.Get(name)
+	if ok {
+		result = c.ValueConverter.ToIntSlice(value)
+	}
+	return result
+}
+
 // IsSet returns if there's a value associated with the key.
 func (c *Default) IsSet(name string) bool {
 	return c.ValueResolver.IsSet(name, c.Repository)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -149,6 +149,15 @@ func TestPropertyStringSlice(t *testing.T) {
 	repository.AssertExpectations(t)
 }
 
+func TestPropertyIntSlice(t *testing.T) {
+	parser := &mocks.ValueConverter{}
+	value := []int{valInt}
+	parser.On("ToIntSlice", value).Return(value)
+	provider, repository := providerWithPropertyAndParser(existent, value, parser)
+	assert.Equal(t, value, provider.IntSlice(existent))
+	repository.AssertExpectations(t)
+}
+
 func providerWithProperty(key string, value interface{}) (config.Provider, mocks.Repository) {
 	return buildDefaultProviderWithProperty(key, value)
 }

--- a/pkg/provider/valueconverter/valueconverter.go
+++ b/pkg/provider/valueconverter/valueconverter.go
@@ -74,4 +74,18 @@ func (p *Default) ToStringSlice(value interface{}) []string {
 	return result
 }
 
-
+// ToIntSlice parses a value into int slice
+func (p *Default) ToIntSlice(value interface{}) []int {
+	var result []int
+	result, ok := value.([]int)
+	if ok {
+		return result
+	}
+	rawValue, ok := value.([]interface{})
+	if ok {
+		for _, intValue := range rawValue {
+			result = append(result, p.ToInt(intValue))
+		}
+	}
+	return result
+}

--- a/pkg/provider/valueconverter/valueconverter_test.go
+++ b/pkg/provider/valueconverter/valueconverter_test.go
@@ -85,3 +85,21 @@ func TestToStringSlice_RawValue(t *testing.T) {
 	expected := []string{"val1", "val2"}
 	assert.Equal(t, expected, parser.ToStringSlice([]interface{}{"val1", "val2"}))
 }
+
+func TestToIntSlice_Success(t *testing.T) {
+	parser := Default{}
+	expected := []int{200, 400, 500}
+	assert.Equal(t, expected, parser.ToIntSlice([]int{200, 400, 500}))
+}
+
+func TestToIntSlice_WrongValue(t *testing.T) {
+	parser := Default{}
+	var expected []int
+	assert.Equal(t, expected, parser.ToIntSlice("val1"))
+}
+
+func TestToIntSlice_RawValue(t *testing.T) {
+	parser := Default{}
+	expected := []int{200, 400, 500}
+	assert.Equal(t, expected, parser.ToIntSlice([]interface{}{200, 400, 500}))
+}


### PR DESCRIPTION
This commit provides a new parser that allows retrieve values within an int slice, associated with the key.

yml example:

![image](https://user-images.githubusercontent.com/53039/143029045-55385aaa-7706-4955-9a55-6088ac579a9f.png)

how to get int values from key:
```
var integers []int = provider.IntSlice("nested.intSlice")
```